### PR TITLE
Bumped handlebars-source version to 4.0.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ rvm:
   - 2.1.0
   - 2.0.0
   - 1.9.3
-
+before_install:
+  - gem update bundler

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 0.8.0
+* bumped handlebars-source version to 4.0.5
+
 # 0.2.3
 
 * expose precompilation method

--- a/handlebars.gemspec
+++ b/handlebars.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files lib README.mdown`.split("\n")
 
   s.add_dependency "therubyracer", "~> 0.12.1"
-  s.add_dependency "handlebars-source", "~> 3.0.0"
+  s.add_dependency "handlebars-source", "~> 4.0.5"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 2.0"
 end

--- a/lib/handlebars/version.rb
+++ b/lib/handlebars/version.rb
@@ -1,3 +1,3 @@
 module Handlebars
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
Handlebars source has an XSS vulnerability in versions prior to 4.0.0.
See: https://gemnasium.com/cowboyd/handlebars.rb/alerts

By bumping handlebars-source to the latest version, we should resolve this vulnerability.

Also adding a step to update bundler in travis as recommended by travis-ci/travis-ci#3531 as a workaround for bundler issue bundler/bundler#3558